### PR TITLE
[typo] settheory.tex: drop duplicate 'chapter'

### DIFF
--- a/settheory.tex
+++ b/settheory.tex
@@ -82,7 +82,7 @@ explain how set theory allows us to speak about relations and
 (therefore) functions. 
 
 \Crefrange{sfr:siz::chap}{sfr:infinite::chap} will then consider some of the
-early achievements of na\"ive set theory. In chapter
+early achievements of na\"ive set theory. In
 \olref[sfr][siz][]{chap}, we explore how to compare sets with regard
 to their size. In \olref[sfr][arith][]{chap}, we explore how one
 might reduce the integers, rationals, and reals to set theory plus


### PR DESCRIPTION
"Chapter" is already part of `\olref[sfr][siz][]{chap}`, see how it's done for other chapters such as one line below:
> In \olref[sfr][arith][]{chap}, we explore how one